### PR TITLE
example

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+import Helpers from 'q.helpers'
+
+console.log(Helpers.Foo)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "q.helpers": "file:./q.helpers"
   },
+  "type": "module",
   "keywords": [],
   "author": "",
   "license": "ISC"

--- a/q.helpers/Foo/index.js
+++ b/q.helpers/Foo/index.js
@@ -1,0 +1,3 @@
+export default {
+  Foo: 'I\'m from Foo'
+}

--- a/q.helpers/Foo/package.json
+++ b/q.helpers/Foo/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "q.helpers.foo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/q.helpers/index.js
+++ b/q.helpers/index.js
@@ -1,0 +1,3 @@
+import Foo from "q.helpers.foo";
+
+export default {Foo}

--- a/q.helpers/package.json
+++ b/q.helpers/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "type": "module",
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "q.helpers.foo": "file:./Foo"
+  }
 }


### PR DESCRIPTION
There would be issues on:

```
import {Foo} from 'q.helpers'
       ^^^
SyntaxError: The requested module 'q.helpers' does not provide an export named 'Foo'
```

instead do whats like in index:

```
import Helpers from 'q.helpers'
console.log(Helpers.Foo)
```

or only import what you want:

```
import Foo from 'q.helpers.Foo'
console.log(Foo)
```




